### PR TITLE
fixed dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
         <plugin.maven-compiler.version>3.0</plugin.maven-compiler.version>
 
-        <dep.flink.version>0.10-SNAPSHOT</dep.flink.version>
+        <dep.flink.version>0.10.1</dep.flink.version>
         <dep.jersey.version>1.19</dep.jersey.version>
         <dep.junit.version>4.12</dep.junit.version>
         <dep.neo4j.version>2.3.0</dep.neo4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <dep.flink.version>0.10.1</dep.flink.version>
         <dep.jersey.version>1.19</dep.jersey.version>
         <dep.junit.version>4.12</dep.junit.version>
-        <dep.neo4j.version>2.3.0</dep.neo4j.version>
+        <dep.neo4j.version>2.3.2</dep.neo4j.version>
     </properties>
 
     <build>
@@ -37,14 +37,52 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+            <version>1.9.13</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-java</artifactId>
+            <artifactId>flink-java_2.11</artifactId>
             <version>${dep.flink.version}</version>
+            <exclusions>
+            <exclusion>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-core-asl</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-mapper-asl</artifactId>
+            </exclusion>
+                <exclusion>
+                    <groupId>com.twitter</groupId>
+                    <artifactId>chill_2.10</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-servlet</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-security</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.twitter</groupId>
+            <artifactId>chill_2.11</artifactId>
+            <version>0.5.2</version>
         </dependency>
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-client</artifactId>
             <version>${dep.jersey.version}</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>
@@ -55,23 +93,71 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-gelly</artifactId>
+            <artifactId>flink-gelly_2.11</artifactId>
             <version>${dep.flink.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-core-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-servlet</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-security</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-test-utils</artifactId>
+            <artifactId>flink-test-utils_2.11</artifactId>
             <version>${dep.flink.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-core-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.twitter</groupId>
+                    <artifactId>chill_2.10</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-servlet</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-security</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>test</scope>
         </dependency>
 
         <!-- Causes problems with overlapping Flink dependencies-->
-        <!--<dependency>-->
-        <!--<groupId>org.neo4j.test</groupId>-->
-        <!--<artifactId>neo4j-harness</artifactId>-->
-        <!--<version>${dep.neo4j.version}</version>-->
-        <!--<scope>test</scope>-->
-        <!--</dependency>-->
+        <dependency>
+            <groupId>org.neo4j.test</groupId>
+            <artifactId>neo4j-harness</artifactId>
+            <version>${dep.neo4j.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/test/java/org/apache/flink/api/java/io/neo4j/Neo4jInputTest.java
+++ b/src/test/java/org/apache/flink/api/java/io/neo4j/Neo4jInputTest.java
@@ -16,8 +16,12 @@ import org.apache.flink.graph.library.PageRank;
 import org.apache.flink.hadoop.shaded.com.google.common.collect.Lists;
 import org.apache.flink.types.NullValue;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.neo4j.harness.junit.Neo4jRule;
 
+import java.io.File;
+import java.net.URI;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -27,10 +31,16 @@ import java.util.concurrent.TimeUnit;
  */
 public class Neo4jInputTest {
 
+  @Rule
+  public Neo4jRule neo4j = new Neo4jRule()
+          .withConfig("dbms.auth.enabled","false")
+          .copyFrom( new File("plwiki.db") );
+
   @SuppressWarnings("unchecked")
   @Test
   public void countTest() throws Exception {
-    String restURI = "http://localhost:7474/db/data/";
+    String restURI = neo4j.httpURI().resolve("/db/data/").toString();
+//    String restURI = "http://localhost:7474/db/data/";
 
     String cypherQuery = "MATCH (p1:Page)-[:Link]->(p2) RETURN id(p1), id(p2)";
 
@@ -41,8 +51,8 @@ public class Neo4jInputTest {
       .setCypherQuery(cypherQuery)
       .setUsername("neo4j")
       .setPassword("test")
-      .setConnectTimeout(1000)
-      .setReadTimeout(1000)
+      .setConnectTimeout(10000)
+      .setReadTimeout(10000)
       .finish();
 
     DataSet<Tuple2<Integer, Integer>> edges = env.createInput(neoInput,
@@ -65,7 +75,8 @@ public class Neo4jInputTest {
   @SuppressWarnings("unchecked")
   @Test
   public void pageRankTest() throws Exception {
-    String restURI = "http://localhost:7474/db/data/";
+    String restURI = neo4j.httpURI().resolve("/db/data/").toString();
+//    String restURI = "http://localhost:7474/db/data/";
     String cypherQuery = "MATCH (p1:Page)-[:Link]->(p2) RETURN id(p1), id(p2)";
 
     ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
@@ -75,8 +86,8 @@ public class Neo4jInputTest {
       .setCypherQuery(cypherQuery)
       .setUsername("neo4j")
       .setPassword("test")
-      .setConnectTimeout(1000)
-      .setReadTimeout(1000)
+      .setConnectTimeout(10000)
+      .setReadTimeout(10000)
       .finish();
 
     DataSet<Tuple3<Integer, Integer, Double>> edges = env.createInput(neoInput,


### PR DESCRIPTION
Exclusions from Flink and Gelly and using Scala _2.11 sub-artifacts
- Scala 2.11
- Eclipse Jetty 9.2.4.v20141103
- Jackson 1.9.13
